### PR TITLE
Courses update

### DIFF
--- a/back/src/KI/PublicationBundle/Controller/CoursesController.php
+++ b/back/src/KI/PublicationBundle/Controller/CoursesController.php
@@ -130,7 +130,11 @@ class CoursesController extends ResourceController
      */
     public function postCourseUserAction($slug, Request $request) {
         $course = $this->findBySlug($slug);
-        $group = $request->query->has('group') ? $request->query->get('group') : null;
+
+        $data = json_decode($request->getContent(), true);
+        $data = is_array($data) ? $data : array();
+
+        $group = array_key_exists("group", $data) ? intval($data["group"]) : 0;
         $this->get('ki_publication.helper.course')->linkCourseUser($course, $this->user, $group);
         return $this->jsonResponse(null, 204);
     }

--- a/back/src/KI/PublicationBundle/Controller/CoursesController.php
+++ b/back/src/KI/PublicationBundle/Controller/CoursesController.php
@@ -132,9 +132,9 @@ class CoursesController extends ResourceController
         $course = $this->findBySlug($slug);
 
         $data = json_decode($request->getContent(), true);
-        $data = is_array($data) ? $data : array();
+        $request->request->replace(is_array($data) ? $data : array());
 
-        $group = array_key_exists("group", $data) ? intval($data["group"]) : 0;
+        $group = $request->request->get('group', 0);
         $this->get('ki_publication.helper.course')->linkCourseUser($course, $this->user, $group);
         return $this->jsonResponse(null, 204);
     }

--- a/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourse.php
+++ b/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourse.php
@@ -14,7 +14,7 @@ class LoadCourseFixture extends AbstractFixture implements OrderedFixtureInterfa
     {
         $course = new Course();
         $course->setName('Devenir Shark en 5 étapes');
-        $course->addGroup('0');
+        $course->addGroup(0);
         $course->setSemester('Ouverture');
         $course->setActive(true);
         $course->setEcts(1.5);
@@ -24,9 +24,9 @@ class LoadCourseFixture extends AbstractFixture implements OrderedFixtureInterfa
 
         $course = new Course();
         $course->setName('Pipeaulogie');
-        $course->addGroup('1');
-        $course->addGroup('2');
-        $course->addGroup('3');
+        $course->addGroup(1);
+        $course->addGroup(2);
+        $course->addGroup(3);
         $course->setSemester('1er Semestre');
         $course->setActive(true);
         $course->setEcts(1);
@@ -36,7 +36,7 @@ class LoadCourseFixture extends AbstractFixture implements OrderedFixtureInterfa
 
         $course = new Course();
         $course->setName('Mécanique des Structures');
-        $course->addGroup('5');
+        $course->addGroup(5);
         $course->setActive(false);
         $course->setEcts(3);
         $course->setSemester('2nd Semestre');
@@ -46,7 +46,7 @@ class LoadCourseFixture extends AbstractFixture implements OrderedFixtureInterfa
 
         $course = new Course();
         $course->setName('Rabotage de quais de RER');
-        $course->addGroup('0');
+        $course->addGroup(0);
         $course->setEcts(4.5);
         $course->setDepartment('VET');
         $manager->persist($course);

--- a/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourseItem.php
+++ b/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourseItem.php
@@ -17,6 +17,7 @@ class LoadCourseItemFixture extends AbstractFixture implements OrderedFixtureInt
         $courseItem->setStartDate(mktime(0, 0, 0, date('n'), date('j')));
         $courseItem->setEndDate(mktime(0, 0, 0, date('n'), date('j')) + 3600*10);
         $courseItem->setCourse($this->getReference('course-shark'));
+        $courseItem->setGroup(2);
         $manager->persist($courseItem);
 
         $courseItem = new CourseItem();
@@ -24,6 +25,7 @@ class LoadCourseItemFixture extends AbstractFixture implements OrderedFixtureInt
         $courseItem->setStartDate(time() + 3600*2.5);
         $courseItem->setEndDate(time() + 3600*4);
         $courseItem->setCourse($this->getReference('course-shark'));
+        $courseItem->setGroup(2);
         $manager->persist($courseItem);
 
         $courseItem = new CourseItem();
@@ -31,6 +33,7 @@ class LoadCourseItemFixture extends AbstractFixture implements OrderedFixtureInt
         $courseItem->setStartDate(time() + 3600*5);
         $courseItem->setEndDate(time() + 3600*6.5);
         $courseItem->setCourse($this->getReference('course-shark'));
+        $courseItem->setGroup(2);
         $manager->persist($courseItem);
 
         $courseItem = new CourseItem();
@@ -38,7 +41,7 @@ class LoadCourseItemFixture extends AbstractFixture implements OrderedFixtureInt
         $courseItem->setStartDate(time() + 3600*3);
         $courseItem->setEndDate(time() + 3600*4.5);
         $courseItem->setCourse($this->getReference('course-pipo'));
-        $courseItem->setGroup('2');
+        $courseItem->setGroup(2);
         $manager->persist($courseItem);
 
         $courseItem = new CourseItem();

--- a/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourseItem.php
+++ b/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourseItem.php
@@ -49,6 +49,7 @@ class LoadCourseItemFixture extends AbstractFixture implements OrderedFixtureInt
         $courseItem->setStartDate(time() + 3600*1);
         $courseItem->setEndDate(time() + 3600*3.5);
         $courseItem->setCourse($this->getReference('course-mecastru'));
+        $courseItem->setGroup(0);
         $manager->persist($courseItem);
 
         $manager->flush();

--- a/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourseUser.php
+++ b/back/src/KI/PublicationBundle/DataFixtures/ORM/LoadCourseUser.php
@@ -15,36 +15,37 @@ class LoadCourseUserFixture extends AbstractFixture implements OrderedFixtureInt
         $courseUser = new CourseUser();
         $courseUser->setCourse($this->getReference('course-shark'));
         $courseUser->setUser($this->getReference('user-taquet-c'));
+        $courseUser->setGroup(0);
         $manager->persist($courseUser);
 
         $courseUser = new CourseUser();
         $courseUser->setCourse($this->getReference('course-shark'));
         $courseUser->setUser($this->getReference('user-trancara'));
-        $courseUser->setGroup('1');
+        $courseUser->setGroup(1);
         $manager->persist($courseUser);
 
         $courseUser = new CourseUser();
         $courseUser->setCourse($this->getReference('course-shark'));
         $courseUser->setUser($this->getReference('user-de-boisc'));
-        $courseUser->setGroup('1');
+        $courseUser->setGroup(1);
         $manager->persist($courseUser);
 
         $courseUser = new CourseUser();
         $courseUser->setCourse($this->getReference('course-shark'));
         $courseUser->setUser($this->getReference('user-muzardt'));
-        $courseUser->setGroup('2');
+        $courseUser->setGroup(2);
         $manager->persist($courseUser);
 
         $courseUser = new CourseUser();
         $courseUser->setCourse($this->getReference('course-shark'));
         $courseUser->setUser($this->getReference('user-guerinh'));
-        $courseUser->setGroup('1');
+        $courseUser->setGroup(1);
         $manager->persist($courseUser);
 
         $courseUser = new CourseUser();
         $courseUser->setCourse($this->getReference('course-rer'));
         $courseUser->setUser($this->getReference('user-muzardt'));
-        $courseUser->setGroup('0');
+        $courseUser->setGroup(0);
         $manager->persist($courseUser);
 
         $manager->flush();

--- a/back/src/KI/PublicationBundle/Entity/CourseItem.php
+++ b/back/src/KI/PublicationBundle/Entity/CourseItem.php
@@ -46,9 +46,9 @@ class CourseItem
 
     /**
      * Groupe
-     * @ORM\Column(name="course_group", type="string", nullable=true)
+     * @ORM\Column(name="course_group", type="integer", nullable=false)
      * @JMS\Expose
-     * @Assert\Type("string")
+     * @Assert\Type("integer")
      */
     protected $group;
 

--- a/back/src/KI/PublicationBundle/Entity/CourseUser.php
+++ b/back/src/KI/PublicationBundle/Entity/CourseUser.php
@@ -21,9 +21,9 @@ class CourseUser
 
     /**
      * Groupe du membre
-     * @ORM\Column(name="course_group", type="string", nullable=true)
+     * @ORM\Column(name="course_group", type="integer", nullable=false)
      * @JMS\Expose
-     * @Assert\Type("string")
+     * @Assert\Type("integer")
      */
     protected $group;
 

--- a/back/src/KI/PublicationBundle/Helper/CourseHelper.php
+++ b/back/src/KI/PublicationBundle/Helper/CourseHelper.php
@@ -49,12 +49,10 @@ class CourseHelper
         $link->setCourse($course);
         $link->setUser($user);
 
-        if ($group !== null) {
-            if (!in_array($group, $course->getGroups())) {
-                throw new BadRequestHttpException('Ce groupe n\'existe pas.');
-            }
-            $link->setGroup($group);
+        if (!in_array($group, $course->getGroups())) {
+            throw new BadRequestHttpException('Ce groupe n\'existe pas.');
         }
+        $link->setGroup($group);
 
         $achievementCheck = new AchievementCheckEvent(Achievement::COURSES);
         $this->dispatcher->dispatch('upont.achievement', $achievementCheck);

--- a/back/src/KI/PublicationBundle/Helper/CourseHelper.php
+++ b/back/src/KI/PublicationBundle/Helper/CourseHelper.php
@@ -35,7 +35,7 @@ class CourseHelper
      * @throws BadRequestHttpException si les deux sont déjà reliés
      * @throws BadRequestHttpException si le groupe n'existe pas pour ce cours
      */
-    public function linkCourseUser(Course $course, User $user, $group = null)
+    public function linkCourseUser(Course $course, User $user, $group = 0)
     {
         $link = $this->courseUserRepository->findBy(array('course' => $course, 'user' => $user));
 

--- a/back/src/KI/PublicationBundle/Helper/CourseParserHelper.php
+++ b/back/src/KI/PublicationBundle/Helper/CourseParserHelper.php
@@ -52,7 +52,7 @@ class CourseParserHelper
             foreach (array_keys($all) as $id) {
                 $name = $courseName[$id];
                 $gr   = str_replace('(&nbsp;)', '', $group[$id]);
-                $gr   = $gr != '' ? (int)str_replace(array('(Gr', ')'), array('', ''), $gr) : 0;
+                $gr   = $gr != '' ? (int) str_replace(array('(Gr', ')'), array('', ''), $gr) : 0;
 
                 $data      = explode(':', $start[$id]);
                 $startDate = $data[0]*3600 + $data[1]*60;

--- a/back/src/KI/PublicationBundle/Helper/CourseParserHelper.php
+++ b/back/src/KI/PublicationBundle/Helper/CourseParserHelper.php
@@ -60,10 +60,10 @@ class CourseParserHelper
                 $endDate   = $data[0]*3600 + $data[1]*60;
 
                 // Si le cours existe déjà, on le récupère, sinon on crée un nouveau cours
-                $course = $this->getOrCreateCourse($name, $department[$id], $gr);
+                $course = $this->getOrCreateCourse($name, $department[$id]);
 
                 // Si le groupe n'est pas connu on le rajoute
-                if (!in_array($gr, $this->knownCourses[$name]['groups'])) {
+                if (!in_array($gr, $this->knownCourses[$name]->getGroups())) {
                     $course->addGroup($gr);
                 }
 
@@ -83,6 +83,17 @@ class CourseParserHelper
 
     private function emptyCourseitems()
     {
+        // $em = $this->manager;
+        // $connection = $em->getConnection();
+        // $statement = $connection->prepare("DELETE FROM upont.CourseItem");
+        // $statement->execute();
+        // $statement = $connection->prepare("DELETE FROM upont.Exercice");
+        // $statement->execute();
+        // $statement = $connection->prepare("DELETE FROM upont.CourseUser");
+        // $statement->execute();
+        // $statement = $connection->prepare("DELETE FROM upont.Course");
+        // $statement->execute();
+
         $query = $this->manager->createQuery('DELETE FROM KIPublicationBundle:CourseItem c WHERE c.startDate > :time');
         $query->setParameter('time', mktime(0, 0, 0));
         $query->execute();
@@ -93,32 +104,23 @@ class CourseParserHelper
         $results = $this->courseRepository->findAll();
         $courses = array();
         foreach ($results as $course) {
-            $courses[$course->getName()] = array(
-                'course' => $course,
-                'groups' => $course->getGroups()
-            );
+            $courses[$course->getName()] = $course;
         }
         return $courses;
     }
 
-    private function getOrCreateCourse($name, $department, $group)
+    private function getOrCreateCourse($name, $department)
     {
-        if (array_key_exists($name, $this->knownCourses)) {
-            $course = $this->knownCourses[$name]['course'];
-        } else {
+        if (!array_key_exists($name, $this->knownCourses)) {
             $course = new Course();
             $course->setName($name);
             $course->setDepartment($department);
             $course->setSemester(0);
-            $course->addGroup($group);
 
             $this->manager->persist($course);
-            $this->knownCourses[$name] = array(
-                'course' => $course,
-                'groups' => array($group)
-            );
+            $this->knownCourses[$name] = $course;
         }
 
-        return $course;
+        return $this->knownCourses[$name];
     }
 }

--- a/back/src/KI/UserBundle/Controller/OwnController.php
+++ b/back/src/KI/UserBundle/Controller/OwnController.php
@@ -508,7 +508,7 @@ class OwnController extends \KI\CoreBundle\Controller\ResourceController
         foreach ($repo->findBy(array('user' => $this->user)) as $courseUser) {
             $course = $courseUser->getCourse();
             foreach ($course->getCourseitems() as $courseitem) {
-                if ($courseUser->getGroup() == $courseitem->getGroup() || $course->getGroups() == array('0') || empty($course->getGroups()) || empty($courseitem->getGroup())) {
+                if ($courseUser->getGroup() == $courseitem->getGroup() || $courseitem->getGroup() == 0) {
                     $result[] = $courseitem;
                     $timestamp[] = $courseitem->getStartDate();
                 }

--- a/front/app/js/controllers/users/calendar.js
+++ b/front/app/js/controllers/users/calendar.js
@@ -1,5 +1,5 @@
 angular.module('upont')
-    .controller('Calendar_Ctrl', ['$rootScope', '$scope', '$filter', 'events', 'courseitems', function($rootScope, $scope, $filter, events, courseitems) {
+    .controller('Calendar_Ctrl', ['$rootScope', '$scope', '$filter', 'events', 'courseitems', '$location', function($rootScope, $scope, $filter, events, courseitems, $location) {
         $scope.events = [];
         for (var i = 0; i < events.length; i++) {
             var type;
@@ -27,7 +27,7 @@ angular.module('upont')
                 type: 'info',
                 startsAt: new Date(courseitems[i].start_date*1000),
                 endsAt: new Date(courseitems[i].end_date*1000),
-                title: '[' + courseitems[i].location + '] ' + courseitems[i].course.name + (group != 0 ? ' (Gr ' + group +')' : ''),
+                title: '[' + courseitems[i].location + '] ' + courseitems[i].course.name + (group !== 0 ? ' (Gr ' + group +')' : ''),
                 editable: false,
                 deletable: false,
                 draggable: false,
@@ -42,6 +42,10 @@ angular.module('upont')
         $scope.setView = function(view) {
             $scope.calendarView = view;
         };
+
+        // $scope.eventClicked = function(calendarEvent) {
+        //     $location.path("root.users.publications.simple({slug: publication.slug})");
+        // };
     }])
     .config(['$stateProvider', function($stateProvider) {
         $stateProvider
@@ -81,6 +85,7 @@ angular.module('upont')
             week: 'Semaine {week}',
         });
         calendarConfigProvider.setDisplayAllMonthEvents(true);
+        calendarConfigProvider.setDisplayEventEndTimes(true);
 
         calendarConfigProvider.setI18nStrings({
             eventsLabel: 'Événements',

--- a/front/app/js/controllers/users/calendar.js
+++ b/front/app/js/controllers/users/calendar.js
@@ -27,7 +27,7 @@ angular.module('upont')
                 type: 'info',
                 startsAt: new Date(courseitems[i].start_date*1000),
                 endsAt: new Date(courseitems[i].end_date*1000),
-                title: '[' + courseitems[i].location + '] ' + courseitems[i].course.name + ((group != '0' && group !== undefined) ? ' (Gr ' + group +')' : ''),
+                title: '[' + courseitems[i].location + '] ' + courseitems[i].course.name + (group != 0 ? ' (Gr ' + group +')' : ''),
                 editable: false,
                 deletable: false,
                 draggable: false,

--- a/front/app/js/controllers/users/resources/courses.js
+++ b/front/app/js/controllers/users/resources/courses.js
@@ -133,8 +133,8 @@ angular.module('upont')
             $scope.isLoading = true;
 
             // S'il y a plusieurs groupes pour ce cours on demande lequel sera suivi
-            if (!empty(course.groups) && course.groups[0] != '0') {
-                alertify.prompt('Dans quel groupe est-tu ? Groupes valides : ' + course.groups.join(','), function(e, str){
+            if (course.groups.length != 1) {
+                alertify.prompt('Dans quel groupe es-tu ? Groupes valides : ' + course.groups.join(','), function(e, str){
                     if (e) {
                         $http.post(apiPrefix + 'courses/' + course.slug + '/attend', {group: str}).success(function() {
                             $resource(apiPrefix + 'own/courses').query(function(data) {


### PR DESCRIPTION
Pour la gestion des cours, il y a vraiment un problème dès qu'il y a des groupes de TD.

Etant donné qu'un cours qui ne possède aucune groupe assigné par l'EDT(=Amphi)  est considéré comme groupe 0, il faudrait : 
- que le groupe d'un membre donné soit obligatoire mais que le cas 0 soit réservé aux cours sans TD.
- que le calendrier affiche alors les événements du groupe éventuel de l'user (TD) ET les événements du groupe 0 (Amphi)
- ne plus faire d'assomptions étranges sur la position de certains éléments dans une liste (https://github.com/KIClubinfo/upont/blob/c248b847849c47d69e428931edd6c3417daa6127/front/app/js/controllers/users/resources/courses.js#L135)
- vider la base de données CourseItem pour effacer tous les anciens cours qui étaient positionnées à de mauvais horaires.
