### PR TITLE
Hotfix CORS headers foyer

### DIFF
--- a/back/app/config/config.yml
+++ b/back/app/config/config.yml
@@ -147,9 +147,9 @@ jms_serializer:
 # Permet d'utiliser l'API depuis d'autres domaines (exemple: foyer.enpc.org)
 nelmio_cors:
     paths:
-        '^/api':
+        '^/':
             allow_origin: ['*']
-            allow_headers: ['x-requested-with']
+            allow_headers: ['*']
             allow_methods: ['POST', 'PUT', 'PATCH', 'GET', 'DELETE', 'OPTIONS']
             max_age: 3600
 


### PR DESCRIPTION
- le chemin testé est ce qu'il y a après /api (ex : /login) => je ne sais pas comment ça faisait pour marcher avant...
- le navigateur fait une requête OPTIONS en demandant les headers "content-type" et "authorization" => j'ai autorisé tous les headers (dangereux ?)
