### PR TITLE
remove legacy connection checking code written in July 2015

### DIFF
--- a/front/app/js/controllers/users/sso.js
+++ b/front/app/js/controllers/users/sso.js
@@ -79,12 +79,6 @@ angular.module('upont')
                 data: {
                     title: 'Authentification centralisée - uPont',
                     top: true
-                },
-                // Déclenchement de l'erreur 401 si non connecté
-                resolve: {
-                    online: ['$resource', function($resource) {
-                        return $resource(apiPrefix + 'online').query().$promise;
-                    }],
                 }
             });
     }]);


### PR DESCRIPTION
La page est réparée, mais on n'a peux pas tester la sso en dev depuis geoponts.enpc.fr car GeoPonts check le nom de domaine de uPont. Normalement à ce stade en prod on tombera sur une page d'erreur de GéoPonts quand la SSO redirige sur leur site.